### PR TITLE
Drop Kotlin Logging as a transitive dependency (caused by `java.lang.NoSuchMethodError`)

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -5,7 +5,6 @@ object Versions {
     const val lagom = "1.6.1" // "1.4.13"
     const val ktlint = "0.41.0"
     const val `ktlint-plugin` = "10.1.0"
-    const val `kotlin-logging` = "1.6.10"
     const val swagger = "2.0.7"
     const val jacoco = "0.8.7"
     const val junit5 = "5.3.2"

--- a/java/impl/build.gradle.kts
+++ b/java/impl/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(kotlin("reflect"))
     implementation(project(":lagom-openapi-core"))
     api(project(":java:lagom-openapi-java-api"))
-    api("io.github.microutils", "kotlin-logging", Versions.`kotlin-logging`)
     compileOnly("com.lightbend.lagom", "lagom-javadsl-server_$scalaBinaryVersion", lagomVersion)
 
     testImplementation(evaluationDependsOn(":lagom-openapi-core").sourceSets.test.get().output)

--- a/java/impl/src/main/kotlin/org/taymyr/lagom/javadsl/openapi/OpenAPIContainer.kt
+++ b/java/impl/src/main/kotlin/org/taymyr/lagom/javadsl/openapi/OpenAPIContainer.kt
@@ -6,12 +6,10 @@ import com.typesafe.config.Config
 import io.swagger.v3.core.util.Json
 import io.swagger.v3.core.util.Yaml
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
-import mu.KotlinLogging
+import org.slf4j.LoggerFactory
 import org.taymyr.lagom.internal.openapi.isAnnotationPresentInherited
 import org.taymyr.lagom.internal.openapi.jsonToYaml
 import org.taymyr.lagom.internal.openapi.yamlToJson
-
-private val log = KotlinLogging.logger {}
 
 internal class OpenAPIContainer(service: Service, config: Config?) {
 
@@ -28,6 +26,8 @@ internal class OpenAPIContainer(service: Service, config: Config?) {
 
     companion object {
         private const val SPEC_CONFIG_PATH = "openapi.file"
+
+        private val log = LoggerFactory.getLogger(OpenAPIContainer::class.java)
 
         fun generateSpecResource(service: Service): OpenAPISpec {
             val api = SpecGenerator().generate(service)
@@ -55,12 +55,12 @@ internal class OpenAPIContainer(service: Service, config: Config?) {
                     spec = openapiSpec?.readText()
                     spec ?: continue
                     protocol = fromFile(filename, YAML)
-                    log.info { "Load OpenAPI specification from $openapiSpec" }
+                    log.info("Load OpenAPI specification from {}", openapiSpec)
                     break
                 } catch (e: Exception) {
                 }
             }
-            if (spec == null) log.error { "OpenAPI specification not found in $paths" }
+            if (spec == null) log.error("OpenAPI specification not found in {}", paths)
             return when (protocol) {
                 JSON -> OpenAPISpec(spec, jsonToYaml(spec))
                 YAML -> OpenAPISpec(yamlToJson(spec), spec)


### PR DESCRIPTION
Caused by getting an error related to a different version of Kotlin in the logging library and Lagom OpenAPI
```
java.lang.NoSuchMethodError: kotlin.jvm.internal.FunctionReferenceImpl.<init>(ILjava/lang/Class;Ljava/lang/String;Ljava/lang/String;I)V
```